### PR TITLE
Add debug test for WebSocket connection closure

### DIFF
--- a/opusagent/websocket_manager.py
+++ b/opusagent/websocket_manager.py
@@ -97,7 +97,7 @@ class RealtimeConnection:
         """Check if this connection can accept another session."""
         try:
             # Check if websocket is still open
-            websocket_open = getattr(self.websocket, 'closed', None) is False or getattr(self.websocket, 'close_code', None) is None
+            websocket_open = getattr(self.websocket, 'closed', None) is False and getattr(self.websocket, 'close_code', None) is None
         except:
             websocket_open = False
             

--- a/test_debug.py
+++ b/test_debug.py
@@ -1,0 +1,56 @@
+import asyncio
+import time
+from unittest.mock import AsyncMock, patch, MagicMock
+from opusagent.websocket_manager import RealtimeConnection, WebSocketManager
+
+async def test_close_debug():
+    """Debug test to understand why close() is not being called."""
+    
+    # Mock the config
+    with patch("opusagent.websocket_manager.WebSocketConfig") as mock_config:
+        mock_config.validate.return_value = None
+        mock_config.MAX_CONNECTIONS = 5
+        mock_config.MAX_CONNECTION_AGE = 3600
+        mock_config.MAX_IDLE_TIME = 300
+        mock_config.HEALTH_CHECK_INTERVAL = 10
+        mock_config.MAX_SESSIONS_PER_CONNECTION = 10
+        mock_config.PING_INTERVAL = 20
+        mock_config.PING_TIMEOUT = 30
+        mock_config.CLOSE_TIMEOUT = 10
+        mock_config.get_websocket_url.return_value = "wss://test.url"
+        mock_config.get_headers.return_value = {"Authorization": "Bearer test"}
+        
+        # Create manager
+        manager = WebSocketManager()
+        
+        # Mock websockets.connect
+        with patch("opusagent.websocket_manager.websockets.connect") as mock_connect:
+            mock_websocket = AsyncMock()
+            mock_websocket.open = True
+            mock_websocket.closed = False
+            
+            # Make the mock return an awaitable coroutine
+            future = asyncio.Future()
+            future.set_result(mock_websocket)
+            mock_connect.return_value = future
+            
+            # Get a connection
+            connection = await manager.get_connection()
+            connection_id = connection.connection_id
+            
+            print(f"Connection created: {connection_id}")
+            print(f"WebSocket object: {connection.websocket}")
+            print(f"WebSocket close method: {connection.websocket.close}")
+            print(f"WebSocket close called before: {connection.websocket.close.called}")
+            
+            # Remove the connection
+            await manager._remove_connection(connection_id)
+            
+            print(f"WebSocket close called after: {connection.websocket.close.called}")
+            print(f"WebSocket close call count: {connection.websocket.close.call_count}")
+            
+            # Check if the connection was removed
+            print(f"Connection in manager: {connection_id in manager._connections}")
+
+if __name__ == "__main__":
+    asyncio.run(test_close_debug()) 

--- a/tests/opusagent/test_websocket_manager.py
+++ b/tests/opusagent/test_websocket_manager.py
@@ -34,6 +34,7 @@ class TestRealtimeConnection:
         websocket = AsyncMock()
         websocket.open = True
         websocket.closed = False
+        websocket.close_code = None  # Ensure close_code is None for correct close logic
         return websocket
 
     @pytest.fixture
@@ -93,7 +94,7 @@ class TestRealtimeConnection:
 
     def test_can_accept_session_websocket_closed(self, connection, mock_websocket):
         """Test can_accept_session when WebSocket is closed."""
-        mock_websocket.open = False
+        mock_websocket.closed = True  # Set closed to True to simulate closed websocket
         assert connection.can_accept_session is False
 
     @pytest.mark.asyncio
@@ -145,6 +146,7 @@ class TestWebSocketManager:
             mock_websocket = AsyncMock()
             mock_websocket.open = True
             mock_websocket.closed = False
+            mock_websocket.close_code = None  # Ensure close_code is None for correct close logic
             # Make the mock return an awaitable coroutine
             future = event_loop.create_future()
             future.set_result(mock_websocket)


### PR DESCRIPTION
This commit introduces a new test script, `test_debug.py`, to investigate the behavior of the `close()` method in the WebSocketManager. The test mocks the WebSocket configuration and connection process, allowing for verification of connection removal and closure behavior. Additionally, the `can_accept_session` method in `RealtimeConnection` is updated to ensure correct logic for open websockets. Relevant adjustments are made in the test suite to align with these changes, enhancing the robustness of WebSocket management testing.